### PR TITLE
fix build on Mac OS X and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ redistribution for both commercial and non-commercial purposes.
 * Run `build.cmd` (for Windows) or `build.sh` (for Linux / Mac ) to build project
 * Copy `src/fsharp` to Atom package folder OR (for easy development) create symbolic directory link beween `src/fsharp` and Atom package folder. It can be done with following command:  
     ``apm develop fsharp <full path to src/fsharp folder>``
-* Open ``src/fsharp`` folder in separate Atom window, press ``Cmd+Shift+P`` (on Mac) or ``Ctrl+Shift+P`` (on Windows or Linux) and select ``Update package dependencies: Update``. It is necessary to install package dependencies specified in ``package.json``
 * Type ``atom -d`` in command line to run Atom in development mode. If you open any F# file errors panel in the bottom should appear.
 
 ### Maintainer(s)

--- a/build.fsx
+++ b/build.fsx
@@ -39,14 +39,14 @@ let gitRaw = environVarOrDefault "gitRaw" "https://raw.github.com/fsprojects"
 let tempReleaseDir = "temp/release"
 
 // Read additional information from the release notes document
-let releaseNotesData = 
+let releaseNotesData =
     File.ReadAllLines "RELEASE_NOTES.md"
     |> parseAllReleaseNotes
 
 let release = List.head releaseNotesData
 
 #if MONO
-let apmTool = "/usr/bin/apm"
+let apmTool = "apm"
 #else
 let apmTool = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) </> "atom" </> "bin" </> "apm.cmd"
 #endif
@@ -65,12 +65,12 @@ Target "BuildGenerator" (fun () ->
     |> Log "AppBuild-Output: "
 )
 
-Target "RunGenerator" (fun () -> 
-    
+Target "RunGenerator" (fun () ->
+
         (TimeSpan.FromMinutes 5.0)
         |> ProcessHelper.ExecProcess (fun p ->
             p.FileName <- __SOURCE_DIRECTORY__ @@ "src" @@ "bin" @@ "Debug" @@ "FSharp.Atom.Generator.exe" )
-        |> ignore    
+        |> ignore
 )
 #if MONO
 #else
@@ -140,7 +140,7 @@ Target "GenerateBindings" (fun () ->
 
 Target "InstallDependencies" (fun _ ->
     let args = "install"
-    
+
     let srcDir = "src/fsharp"
     let result =
         ExecProcess (fun info ->
@@ -172,9 +172,9 @@ Target "PushToMaster" (fun _ ->
         CleanDir tempReleaseDir
         CopyRecursive tempGitDir (tempReleaseDir  </> ".git") true |> ignore
 
-    cleanEverythingFromLastCheckout()    
-    CopyRecursive "src/fsharp" tempReleaseDir true |> tracefn "%A"    
-   
+    cleanEverythingFromLastCheckout()
+    CopyRecursive "src/fsharp" tempReleaseDir true |> tracefn "%A"
+
     StageAll tempReleaseDir
     Git.Commit.Commit tempReleaseDir (sprintf "Release %s" release.NugetVersion)
     Branches.push tempReleaseDir
@@ -198,7 +198,7 @@ Target "Default" DoNothing
 
 #if MONO
 "Clean"
-  ==> "BuildGenerator" 
+  ==> "BuildGenerator"
   ==> "RunGenerator"
   ==> "InstallDependencies"
 #else

--- a/src/fsharp/README.md
+++ b/src/fsharp/README.md
@@ -32,7 +32,6 @@ redistribution for both commercial and non-commercial purposes.
 * Run `build.cmd` (for Windows) or `build.sh` (for Linux / Mac ) to build project
 * Copy `src/fsharp` to Atom package folder OR (for easy development) create symbolic directory link beween `src/fsharp` and Atom package folder. It can be done with following command:  
     ``apm develop fsharp <full path to src/fsharp folder>``
-* Open ``src/fsharp`` folder in separate Atom window, press ``Cmd+Shift+P`` (on Mac) or ``Ctrl+Shift+P`` (on Windows or Linux) and select ``Update package dependencies: Update``. It is necessary to install package dependencies specified in ``package.json``
 * Type ``atom -d`` in command line to run Atom in development mode. If you open any F# file errors panel in the bottom should appear.
 
 ### Maintainer(s)


### PR DESCRIPTION
I've tried to run build on Mac OS X, but it failed due to apm is not located in /usr/bin. Actually, it is not necessary to specify full path to apm, because Mac knows where apm is located. 
However I am not sure that it will work on Linux (but I suppose it should work)